### PR TITLE
Remove cypress from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@typescript-eslint/parser": "^4.9.0",
     "@webpack-cli/serve": "^1.1.0",
     "css-loader": "^5.0.1",
-    "cypress": "^6.0.1",
     "dotenv-webpack": "^6.0.0",
     "eslint": "^7.14.0",
     "eslint-plugin-i18n-json": "^3.1.0",

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,15 @@
             <version>${maven-frontend-plugin.version}</version>
             <executions>
               <execution>
+                <id>npm install cypress</id>
+                <goals>
+                  <goal>npm</goal>
+                </goals>
+                <configuration>
+                  <arguments>install cypress@^6.0.1 --verbose</arguments>
+                </configuration>
+              </execution>
+              <execution>
                 <id>npm deploy dist</id>
                 <goals>
                   <goal>npm</goal>


### PR DESCRIPTION
Cypress fails to install in PNC. It tries to download a lot of stuff from the internet which is blocked in PNC. 

The default "npm install" always tries to install it even without enabling "e2e". This is the only way I found to solve the issue.