### PR TITLE
ISPN-11492 Cluster and Cache enable/disable rebalancing

### DIFF
--- a/src/app/CacheManagers/CacheManagers.tsx
+++ b/src/app/CacheManagers/CacheManagers.tsx
@@ -29,6 +29,7 @@ import {useTranslation} from 'react-i18next';
 import {useConnectedUser} from "@app/services/userManagementHook";
 import {ConsoleServices} from "@services/ConsoleServices";
 import {ConsoleACL} from "@services/securityService";
+import {RebalancingCacheManager} from "@app/CacheManagers/RebalancingCacheManager";
 
 const CacheManagers = () => {
   const { connectedUser } = useConnectedUser();
@@ -207,6 +208,7 @@ const CacheManagers = () => {
               <Status status={cm.cache_manager_status} />
             </FlexItem>
             {buildSiteDisplay(cm.local_site)}
+            <RebalancingCacheManager/>
           </Flex>
         </Flex>
         {buildTabs()}

--- a/src/app/CacheManagers/RebalancingCacheManager.tsx
+++ b/src/app/CacheManagers/RebalancingCacheManager.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import {Divider, FlexItem, Spinner, Switch} from '@patternfly/react-core';
+import {useConnectedUser} from "@app/services/userManagementHook";
+import {ConsoleServices} from "@services/ConsoleServices";
+import {ConsoleACL} from "@services/securityService";
+import {useTranslation} from "react-i18next";
+import {useApiAlert} from "@app/utils/useApiAlert";
+import {useDataContainer} from "@app/services/dataContainerHooks";
+
+const RebalancingCacheManager = () => {
+  const { addAlert } = useApiAlert();
+  const { t } = useTranslation();
+  const { connectedUser } = useConnectedUser();
+  const { cm, loading, reload } = useDataContainer();
+
+  if (loading || !cm) {
+    return (
+      <FlexItem>
+        <Spinner size={'md'} />
+      </FlexItem>
+    );
+  }
+
+  if (ConsoleServices.security().hasConsoleACL(ConsoleACL.ADMIN, connectedUser) && cm.rebalancing_enabled != undefined) {
+    return (
+      <React.Fragment>
+        <Divider isVertical />
+        <FlexItem>
+          <Switch
+            id="rebalancing-switch"
+            label={t('cache-managers.rebalancing-enabled')}
+            labelOff={t('cache-managers.rebalancing-disabled')}
+            isChecked={cm.rebalancing_enabled}
+            onChange={() => {
+              ConsoleServices.dataContainer().rebalancing(cm.name, !cm.rebalancing_enabled)
+                .then(r => {
+                  addAlert(r);
+                  reload();
+                })
+            }}
+          />
+        </FlexItem>
+      </React.Fragment>
+    );
+  }
+
+  // Return nothing if the connected user is not ADMIN
+  return (<FlexItem></FlexItem>);
+};
+
+export { RebalancingCacheManager };

--- a/src/app/Caches/DetailCache.tsx
+++ b/src/app/Caches/DetailCache.tsx
@@ -43,6 +43,7 @@ import {ConsoleServices} from "@services/ConsoleServices";
 import {ConsoleACL} from "@services/securityService";
 import {useConnectedUser} from "@app/services/userManagementHook";
 import {useTranslation} from "react-i18next";
+import {RebalancingCache} from "@app/Caches/RebalancingCache";
 
 const DetailCache = (props: { cacheName: string }) => {
   const cacheName = props.cacheName;
@@ -104,17 +105,7 @@ const DetailCache = (props: { cacheName: string }) => {
   };
 
   const buildDetailContent = () => {
-    if (loading) {
-      return (
-        <Card>
-          <CardBody>
-            <Spinner size="xl" />
-          </CardBody>
-        </Card>
-      );
-    }
-
-    if (error.length > 0 || !cache) {
+    if (error.length > 0) {
       return (
         <Card>
           <CardBody>
@@ -142,6 +133,16 @@ const DetailCache = (props: { cacheName: string }) => {
       );
     }
 
+    if (loading || !cache) {
+      return (
+        <Card>
+          <CardBody>
+            <Spinner size="xl" />
+          </CardBody>
+        </Card>
+      );
+    }
+
     if(activeTabKey1 == 0
       && cache.editable
       && ConsoleServices.security().hasCacheConsoleACL(ConsoleACL.READ, cacheName, connectedUser)) {
@@ -162,6 +163,8 @@ const DetailCache = (props: { cacheName: string }) => {
   };
 
   const buildRebalancing = () => {
+    if (!cache) return ;
+
     if (!cache?.rehash_in_progress) {
       return (
         <ToolbarItem>
@@ -308,7 +311,7 @@ const DetailCache = (props: { cacheName: string }) => {
           </ToolbarItem>
         </ToolbarGroup>
         <ToolbarGroup>
-          {buildRebalancing()}
+          <RebalancingCache/>
           {buildBackupsManage()}
           {buildIndexManage()}
         </ToolbarGroup>
@@ -416,7 +419,12 @@ const DetailCache = (props: { cacheName: string }) => {
           activeKey={activeTabKey1}
           isSecondary={true}
           component={TabsComponent.nav}
-          onSelect={(event, tabIndex) => setActiveTabKey1(tabIndex)}
+          onSelect={(event, tabIndex) => {
+            setActiveTabKey1(tabIndex);
+            if (tabIndex == 0) {
+              loadCache(cacheName);
+            }
+          }}
         >
           {displayCacheEntries()}
           {displayConfiguration()}

--- a/src/app/Caches/RebalancingCache.tsx
+++ b/src/app/Caches/RebalancingCache.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import {Label, Spinner, Switch, ToolbarItem} from '@patternfly/react-core';
+import {useCacheDetail} from "@app/services/cachesHook";
+import {useConnectedUser} from "@app/services/userManagementHook";
+import {ConsoleServices} from "@services/ConsoleServices";
+import {ConsoleACL} from "@services/securityService";
+import {useTranslation} from "react-i18next";
+import {useApiAlert} from "@app/utils/useApiAlert";
+import {useDataContainer} from "@app/services/dataContainerHooks";
+
+const RebalancingCache = () => {
+  const { addAlert } = useApiAlert();
+  const { t } = useTranslation();
+  const { connectedUser } = useConnectedUser();
+  const { cache, cacheManager, loading, reload } = useCacheDetail();
+
+  // If rebalancing is not activated at cluster level, don't display anything
+  if (!cacheManager.rebalancing_enabled || cache.rebalancing_enabled == undefined) {
+    return ( <ToolbarItem/>)
+  }
+
+  if (loading || !cache) {
+    return (
+      <ToolbarItem>
+        <Spinner size={'md'} />
+      </ToolbarItem>
+    );
+  }
+
+  /**
+   * When the rehash is in progress just display the value
+   */
+  if (cache?.rehash_in_progress) {
+    return (
+      <ToolbarItem>
+        <Spinner size={'md'} /> {t('caches.info.rebalancing')}
+      </ToolbarItem>
+    );
+  }
+
+  /**
+   * If the user is ADMIN, can enable and disable rebalancing
+   */
+  if (ConsoleServices.security().hasConsoleACL(ConsoleACL.ADMIN, connectedUser)) {
+    return (
+      <ToolbarItem>
+        <Switch
+          id="rebalancing-switch"
+          label={t('caches.info.rebalancing-enabled')}
+          labelOff={t('caches.info.rebalancing-disabled')}
+          isChecked={cache.rebalancing_enabled}
+          onChange={() => {
+            ConsoleServices.caches().rebalancing(cache.name, !cache.rebalancing_enabled)
+              .then(r => {
+                addAlert(r);
+                reload();
+              })
+          }}
+        />
+      </ToolbarItem>
+    );
+  }
+
+  if (cache.rebalancing_enabled) {
+    return (
+      <ToolbarItem>
+        <Label>{t('caches.info.rebalanced')}</Label>
+      </ToolbarItem>
+    );
+  }
+
+  return (
+    <ToolbarItem>
+      <Label>{t('caches.info.rebalancing-disabled')}</Label>
+    </ToolbarItem>
+  );
+};
+
+export { RebalancingCache };

--- a/src/app/assets/languages/en.json
+++ b/src/app/assets/languages/en.json
@@ -59,6 +59,7 @@
     "ignore" : "Hide",
     "undo-ignore" : "Show",
     "ignored-status" : "Hidden",
+    "rebalancing-disabled-status" : "Rebalancing off",
     "delete" : "Delete",
     "clear-all-button" : "Clear all",
     "no-caches-status" : "No caches found",
@@ -104,7 +105,9 @@
     "allowed-role" : "Allowed role",
     "allowed-role-null" : "-",
     "no-tasks-status" : "No tasks yet",
-    "no-tasks-body" : "Create tasks with the CLI or a remote client."
+    "no-tasks-body" : "Create tasks with the CLI or a remote client.",
+    "rebalancing-enabled": "Rebalancing is on",
+    "rebalancing-disabled": "Rebalancing is off"
   },
   "caches" : {
     "configuration" : {
@@ -129,7 +132,8 @@
       "loading" : "Loading cache {{cacheName}} ...",
       "error" : "An error occurred while loading {{cacheName}}",
       "rebalanced" : "Rebalanced",
-      "rebalancing" : "Rebalancing"
+      "rebalancing-enabled" : "Rebalancing is on",
+      "rebalancing-disabled" : "Rebalancing is off"
     },
     "actions" : {
       "action-see-less" : "See fewer cache details",

--- a/src/app/providers/CacheManagerContextProvider.tsx
+++ b/src/app/providers/CacheManagerContextProvider.tsx
@@ -9,6 +9,7 @@ const initialContext = {
   caches: [] as CacheInfo[],
   loadingCaches: true,
   errorCaches: '',
+  reload: () => {},
   reloadCaches: () => {},
 };
 
@@ -76,6 +77,10 @@ const ContainerDataProvider = ({ children }) => {
     }
   }, [cm, loadingCaches]);
 
+  const reload = () => {
+    setLoading(true);
+  };
+
   const reloadCaches = () => {
     setLoadingCaches(true);
   };
@@ -87,6 +92,7 @@ const ContainerDataProvider = ({ children }) => {
     cm: cm,
     loadingCaches: loadingCaches,
     errorCaches: errorCaches,
+    reload: useCallback(reload, []),
     reloadCaches: useCallback(reloadCaches, []),
   };
 

--- a/src/app/services/cachesHook.ts
+++ b/src/app/services/cachesHook.ts
@@ -54,9 +54,9 @@ export function useCacheEntries() {
 }
 
 export function useCacheDetail() {
-  const { cache, loading, error, loadCache, reload } = useContext(
+  const { cache, loading, error, loadCache, reload, cacheManager } = useContext(
     CacheDetailContext
   );
 
-  return { cache, loading, error, loadCache, reload };
+  return { cache, loading, error, loadCache, reload, cacheManager };
 }

--- a/src/app/services/dataContainerHooks.ts
+++ b/src/app/services/dataContainerHooks.ts
@@ -2,11 +2,12 @@ import { useContext } from 'react';
 import { DataContainerContext } from '@app/providers/CacheManagerContextProvider';
 
 export function useDataContainer() {
-  const { cm, loading, error } = useContext(DataContainerContext);
+  const { cm, loading, error, reload } = useContext(DataContainerContext);
   return {
     loading,
     error,
     cm,
+    reload
   };
 }
 

--- a/src/services/cacheConfigUtils.ts
+++ b/src/services/cacheConfigUtils.ts
@@ -1,5 +1,5 @@
 import { ContentType, EncodingType } from '@services/infinispanRefData';
-import {Either, left, right} from "@services/either";
+import { Either, left, right } from '@services/either';
 
 export const Distributed = 'distributed-cache';
 export const Replicated = 'replicated-cache';
@@ -11,18 +11,17 @@ export const Scattered = 'scattered-cache';
  * Utility class to map cache configuration
  */
 export class CacheConfigUtils {
-
   /**
    * Validates a configuration of cache may have a correct format and detects if it's
    * a valid formatted json or a xml.
    *
    * @param config
    */
-  public static validateConfig (config: string): Either<string, 'xml' | 'json'> {
+  public static validateConfig(config: string): Either<string, 'xml' | 'json'> {
     const trimmedConf = config.trim();
 
     if (trimmedConf.length == 0) {
-      return left('Configuration can\'t be empty');
+      return left("Configuration can't be empty");
     }
     try {
       JSON.parse(trimmedConf);
@@ -36,7 +35,7 @@ export class CacheConfigUtils {
       }
     } catch (ex) {}
     return left('The provided configuration is not a valid XML or JSON.');
-  };
+  }
 
   /**
    * Map the encoding type of the cache

--- a/src/services/cacheService.ts
+++ b/src/services/cacheService.ts
@@ -68,6 +68,7 @@ export class CacheService {
           size: data['size'],
           rehash_in_progress: data['rehash_in_progress'],
           indexing_in_progress: data['indexing_in_progress'],
+          rebalancing_enabled: data['rebalancing_enabled'],
           editable:
             CacheConfigUtils.isEditable(keyValueEncoding.key as EncodingType) &&
             CacheConfigUtils.isEditable(keyValueEncoding.value as EncodingType),
@@ -551,5 +552,29 @@ export class CacheService {
           )
         )
       );
+  }
+
+  /**
+   * Enables or disables rebalancing on a cache
+   * @param cacheName
+   * @param enable, true to enable, false for disable
+   */
+  public async rebalancing(
+    cacheName: string,
+    enable: boolean
+  ): Promise<ActionResponse> {
+    const action = enable ? 'enable' : 'disable';
+    const url =
+      this.endpoint +
+      '/caches/' +
+      encodeURIComponent(cacheName) +
+      '?action=' +
+      action +
+      '-rebalancing';
+    return this.fetchCaller.post({
+      url: url,
+      successMessage: `Cache ${cacheName} rebalancing successfully ${action}d.`,
+      errorMessage: `Unexpected error when cache ${cacheName} rebalancing ${action}d.`,
+    });
   }
 }

--- a/src/types/InfinispanTypes.ts
+++ b/src/types/InfinispanTypes.ts
@@ -16,6 +16,7 @@ interface CacheManager {
   cluster_members: [ClusterMember];
   health: string;
   local_site?: string;
+  rebalancing_enabled?: boolean;
 }
 
 interface ClusterMember {
@@ -76,6 +77,7 @@ interface CacheInfo {
   simpleCache: boolean;
   health: string;
   features: Features;
+  rebalancing_enabled?: boolean;
 }
 
 interface CacheEntry {
@@ -113,6 +115,7 @@ interface DetailedInfinispanCache {
   size?: number;
   rehash_in_progress?: boolean;
   indexing_in_progress?: boolean;
+  rebalancing_enabled?: boolean;
   editable: boolean;
   queryable: boolean;
   features: Features;


### PR DESCRIPTION
This PR includes for facility and testing 3 rebalancing features.

Only for admins (observer should not access this feature for example)
* Enable/disable rebalancing at cluster level
* Enable/disable rebalancing at cache level if rebalancing is enabled at cluster level.

For all the users
* Display a "rebalancing off" badge in the cache list when rebalancing is enabled at cluster level and the cache in the list has rebalancing disabled.

### ISSUE https://issues.redhat.com/browse/ISPN-11491

Cluster Level

<img width="334" alt="Screenshot 2021-09-16 at 23 43 35" src="https://user-images.githubusercontent.com/233499/133689815-3ee78b20-2982-4412-8739-b6ffe966f3d8.png">

### ISSUE https://issues.redhat.com/browse/ISPN-11492

Cache Level

<img width="359" alt="Screenshot 2021-09-16 at 23 43 42" src="https://user-images.githubusercontent.com/233499/133689825-9940eb56-3695-4cd0-ab52-f388b5a5e4a4.png">
>

If rebalancing is globally disabled, the cache detail does not display anything

Cluster View List of Caches. When the cache has rebalancing disabled, display a badge.

### ISSUE https://issues.redhat.com/browse/ISPN-11493


<img width="1174" alt="Screenshot 2021-09-17 at 16 33 14" src="https://user-images.githubusercontent.com/233499/133800653-31e2c6f4-13ae-48a7-8dc3-544caa8dfce7.png">


Depends on this PR: https://github.com/infinispan/infinispan/pull/9519
