### PR TITLE
ISPN-14054 Add protobuf schema using Upload on the console

### DIFF
--- a/src/app/ProtoSchema/CreateProtoSchema.tsx
+++ b/src/app/ProtoSchema/CreateProtoSchema.tsx
@@ -3,6 +3,7 @@ import {
   Alert,
   AlertVariant,
   Button,
+  FileUpload,
   Form,
   FormGroup,
   Modal,
@@ -39,6 +40,30 @@ const CreateProtoSchema = (props: { isModalOpen: boolean; closeModal: (boolean) 
   const [error, setError] = useState<string | undefined>(undefined);
   const [schemaName, setSchemaName] = useState<IField>(schemaNameInitialState);
   const [schema, setSchema] = useState<IField>(schemaInitialState);
+
+  const [filename, setFilename] = React.useState('');
+
+  const handleFileInputChange = (_, file: File) => {
+    setFilename(file.name);
+  };
+
+  const handleClear = (_event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    setFilename('');
+    setError(undefined);
+    setSchema(schemaInitialState);
+  };
+
+  const handleSchemaContentChange = (_event, v) => {
+    setSchema((prevState) => {
+      return { ...prevState, value: v };
+    })
+  }
+
+  const fileUploadDropZoneProps = {
+    accept: { 'application/x-protobuf': ['.proto','.pb'] },
+    onDropRejected: ()=> setError('Invalid File Type! Please upload a protbuf file.'),
+    onDropAccepted: ()=> setError('')
+  }
 
   const clearCreateProtoSchema = (createDone: boolean) => {
     setSchemaName(schemaNameInitialState);
@@ -106,20 +131,22 @@ const CreateProtoSchema = (props: { isModalOpen: boolean; closeModal: (boolean) 
           isRequired
           fieldId="schema-content"
         >
-          <TextArea
-            value={schema.value}
+          <FileUpload
             id="schema"
-            name="schema"
+            type="text"
+            name='schema'
             aria-describedby="schema-content-helper"
-            height={400}
-            resizeOrientation={TextAreResizeOrientation.vertical}
-            onChange={(_event, v) =>
-              setSchema((prevState) => {
-                return { ...prevState, value: v };
-              })
-            }
+            value={schema.value}
+            filename={filename}
+            filenamePlaceholder="Drag and drop Protobuf Schema file or upload one"
+            onFileInputChange={handleFileInputChange}
+            onDataChange={handleSchemaContentChange}
+            onTextChange={handleSchemaContentChange} 
+            dropzoneProps={fileUploadDropZoneProps}
+            onClearClick={handleClear}
+            allowEditingUploadedText={true}
+            browseButtonText="Upload"
             validated={schema.validated}
-            rows={15}
           />
         </FormGroup>
       </Form>

--- a/src/app/ProtoSchema/ProtobufSchemasDisplay.css
+++ b/src/app/ProtoSchema/ProtobufSchemasDisplay.css
@@ -4,3 +4,7 @@
   --pf-v5-c-table--cell--Overflow: auto;
   --pf-v5-c-table--cell--WhiteSpace: nowrap;
 }
+
+.pf-v5-c-file-upload{
+  --pf-v5-c-file-upload__file-details__c-form-control--MinHeight : 300px
+}


### PR DESCRIPTION
<!--- If this is a non-code change, this template is not required; reference any issues or top-level descriptions as needed -->
<!--- All code change PRs should relate to an issue, reference it here; see example below -->
<!--- Closes: #123 -->
Closes: #400 

## Description
<!--- Describe your changes in detail; the what, the why, any findings, etc -->
<!--- Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Added File upload Feature to upload protobuf schema from console.

UI change : 
![Screenshot 2023-11-01 132254](https://github.com/infinispan/infinispan-console/assets/61231732/47c2b729-1c50-470c-a9c6-9cefa10551ff)

## How Has This Been Tested?
<!--- Please mention to steps to reproduce to see changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally.
## Test Impact
<!--- What tests have you done to covert implemented functionality -->
<!--- If tests are not applicable, explain why here -->
User will be able to upload protobuf schema files along with manual text input.
## Request review criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Commit message includes a reference to the corresponding JIRA issue (eg. commit message: "ISPN-1234 JIRA TITLE...").
- [x] Commits have been squashed and self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.