### PR TITLE
Bump actions/upload-artifact@4.4.3

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -80,7 +80,7 @@ jobs:
           config-file: cypress.config.ts
 
       - name: Uploading test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.4.3
         if: failure()
         with:
           name: screenshots


### PR DESCRIPTION
actions/upload-artifact@v3 is going to be dismissed in 2025