### PR TITLE
[#615] Make Cypress tests execution stabel under Firefox and Chrome browsers

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -34,11 +34,13 @@ jobs:
 
       # It's not possible to use GH action services, as we need to mount custom configuration from checked out source to the server
       - if: github.base_ref == 'main' || github.ref_name == 'main'
-        name: Start 2 Cross-site Infinispan Servers Latest Version
+        name: Start 2 Cross-site Infinispan Servers Latest Version, Local server and Server with diff version
         shell: bash
         run: |
           docker run -d -p 11222:11222 -v ${{ github.workspace }}/scripts/identities.batch:/user-config/identities.batch -v ${{ github.workspace }}/dist:/opt/infinispan/static/console -v ${{ github.workspace }}/scripts/e2eTestsConfigLON.xml:/user-config/e2eTestsConfigLON.xml -e JAVA_OPTIONS="-Xms1024m -Xmx3072m -XX:MetaspaceSize=1024m -XX:MaxMetaspaceSize=2048m -Dinfinispan.site.name=LON -Djgroups.mcast_port=46656" -e IDENTITIES_BATCH="/user-config/identities.batch" quay.io/infinispan-test/server:main --node-name=infinispan-4-lon-e2e -c "infinispan-xsite.xml" -c "/user-config/e2eTestsConfigLON.xml"
           docker run -d -p 31222:11222 -v ${{ github.workspace }}/scripts/identities.batch:/user-config/identities.batch -v ${{ github.workspace }}/dist:/opt/infinispan/static/console -v ${{ github.workspace }}/scripts/e2eTestsConfigNYC.xml:/user-config/e2eTestsConfigNYC.xml -e JAVA_OPTIONS="-Xms1024m -Xmx3072m -XX:MetaspaceSize=1024m -XX:MaxMetaspaceSize=2048m -Dinfinispan.site.name=NYC -Djgroups.mcast_port=46666" -e IDENTITIES_BATCH="/user-config/identities.batch" quay.io/infinispan-test/server:main --node-name=infinispan-4-nyc-e2e -c "infinispan-xsite.xml" -c "/user-config/e2eTestsConfigNYC.xml"
+          docker run -d -p 41222:11222 -v ${{ github.workspace }}/scripts/identities.batch:/user-config/identities.batch -v ${{ github.workspace }}/dist:/opt/infinispan/static/console -v ${{ github.workspace }}/scripts/infinispan-local.xml:/user-config/infinispan-local.xml -e JAVA_OPTIONS="-Xms1024m -Xmx3072m -XX:MetaspaceSize=1024m -XX:MaxMetaspaceSize=2048m" -e IDENTITIES_BATCH="/user-config/identities.batch" quay.io/infinispan-test/server:main --node-name=infinispan-4-local-e2e -c "/user-config/infinispan-local.xml"
+          docker run --name ispn-nyc-1 -d -p 51222:11222 -v ${{ github.workspace }}/scripts/identities.batch:/user-config/identities.batch -v ${{ github.workspace }}/dist:/opt/infinispan/static/console -v ${{ github.workspace }}/scripts/e2eTestsConfigNYC.xml:/user-config/e2eTestsConfigNYC.xml -e JAVA_OPTIONS="-Xms1024m -Xmx3072m -XX:MetaspaceSize=1024m -XX:MaxMetaspaceSize=2048m -Dinfinispan.site.name=NYC -Djgroups.mcast_port=46666" -e IDENTITIES_BATCH="/user-config/identities.batch" quay.io/infinispan/server:16.0.0.Dev02-1 --node-name=infinispan-4-nyc-1-e2e -c infinispan-xsite.xml -c "/user-config/e2eTestsConfigNYC.xml"
           # Wait for server to startup
           curl --fail --silent --show-error --retry-all-errors --retry 240 --retry-delay 1 http://localhost:11222/rest/v2/cache-managers/default/health/status > /dev/null
           curl --fail --silent --show-error --retry-all-errors --retry 240 --retry-delay 1 http://localhost:31222/rest/v2/cache-managers/default/health/status > /dev/null
@@ -100,6 +102,8 @@ jobs:
           # Wait for servers to startup
           curl --fail --silent --show-error --retry-all-errors --retry 240 --retry-delay 1 http://localhost:11222/rest/v2/cache-managers/default/health/status > /dev/null
           curl --fail --silent --show-error --retry-all-errors --retry 240 --retry-delay 1 http://localhost:31222/rest/v2/cache-managers/default/health/status > /dev/null
+          curl --fail --silent --show-error --retry-all-errors --retry 240 --retry-delay 1 http://localhost:41222/rest/v2/cache-managers/default/health/status > /dev/null
+          curl --fail --silent --show-error --retry-all-errors --retry 240 --retry-delay 1 http://localhost:51222/rest/v2/cache-managers/default/health/status > /dev/null
 
       - name: Initialize Infinispan Server
         run: cd data; bash ./create-data.sh admin password

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -18,6 +18,22 @@ export default defineConfig({
     // We've imported your old cypress plugins here.
     // You may want to clean this up later by importing these.
     setupNodeEvents(on, config) {
+      on('before:browser:launch', (browser = {}, launchOptions) => {
+        if (browser.name === 'firefox') {
+          launchOptions.preferences['browser.download.manager.alertOnEXEOpen'] = false;
+          launchOptions.preferences['browser.helperApps.neverAsk.saveToDisk'] = 'application/csv, text/csv, text/plain,application/octet-stream doc xls pdf txt xml json';
+          launchOptions.preferences['browser.download.manager.focusWhenStarting'] = false;
+          launchOptions.preferences['browser.download.useDownloadDir'] = true;
+          launchOptions.preferences['browser.helperApps.alwaysAsk.force'] = false;
+          launchOptions.preferences['browser.download.manager.closeWhenDone'] = true;
+          launchOptions.preferences['browser.download.manager.showAlertOnComplete'] = false;
+          launchOptions.preferences['browser.download.manager.useWindow'] = false;
+          launchOptions.preferences['services.sync.prefs.sync.browser.download.manager.showWhenStarting'] = false;
+          launchOptions.preferences['pdfjs.disabled'] = true;
+
+          return launchOptions;
+        }
+      });
       return require('./cypress/plugins/index.js')(on, config)
     },
     baseUrl: 'http://localhost:11222/console/'

--- a/cypress/e2e/1_acess_management.cy.js
+++ b/cypress/e2e/1_acess_management.cy.js
@@ -81,7 +81,7 @@ describe('Access Management', () => {
     cy.get('[data-cy=grantAccessPrincipalButton').click();
     cy.get("[aria-label=principal-name-input]").type("aPrincipal");
     cy.get("[data-cy=menu-toogle-roles]").click();
-    cy.get("[data-cy=option-typeahead-deployer]").click({animationDistanceThreshold: 20});
+    cy.get("[data-cy=option-typeahead-deployer]").click({animationDistanceThreshold: 20, waitForAnimations: false});
     cy.get("[data-cy=menu-toogle-roles]").click();
     cy.get('[aria-label=Save').click();
     cy.contains('Access granted to aPrincipal.');

--- a/cypress/e2e/1_cluster-welcome.cy.js
+++ b/cypress/e2e/1_cluster-welcome.cy.js
@@ -30,7 +30,7 @@ describe('Welcome page', () => {
 
     if (Cypress.browser.name === 'firefox') {
       cy.contains('admin');
-      cy.get('[aria-label*="incognito"]').should('exist');
+      cy.get('[aria-label*="more-info-close"]').should('exist');
     } else {
       //Checks that user's dropbox exists on the page.
       cy.contains('admin').click();

--- a/cypress/e2e/1_rbac_func.cy.js
+++ b/cypress/e2e/1_rbac_func.cy.js
@@ -4,6 +4,14 @@ describe('RBAC Functionality Tests', () => {
   const applicationUserName = 'application';
   const deployerUserName = 'deployer';
 
+  beforeEach(() => {
+    // cleanup created data for a-rbac-test-cache
+    cy.cleanupTest(Cypress.env('username'), Cypress.env('password'), '/caches/a-rbac-test-cache/fordCar', 'DELETE')
+    cy.cleanupTest(Cypress.env('username'), Cypress.env('password'), '/caches/a-rbac-test-cache/kiaCar', 'DELETE')
+    cy.cleanupTest(Cypress.env('username'), Cypress.env('password'), '/caches/indexed-cache-no-auth/stringKey', 'DELETE')
+    cy.cleanupTest(Cypress.env('username'), Cypress.env('password'), '/caches/indexed-cache-no-auth/stringKey1', 'DELETE')
+  });
+
   it('successfully logins and performs actions with monitor user', () => {
     cy.login(monitorUserName, Cypress.env('password'));
     checkDataContainerView(true, false, false, false);

--- a/cypress/e2e/2_cache-detail-search.cy.js
+++ b/cypress/e2e/2_cache-detail-search.cy.js
@@ -25,6 +25,7 @@ describe('Cache Detail Overview', () => {
     cy.get('[data-cy=deleteButton]').click();
     cy.get('button[aria-label=searchButton]').click();
     cy.contains('Values not found.');
+    cy.get('[data-cy=deleteByQueryButton]').should('be.disabled');
   })
 
   it('successfully searches by values', () => {

--- a/cypress/e2e/3_cache-aliases.cy.js
+++ b/cypress/e2e/3_cache-aliases.cy.js
@@ -35,10 +35,18 @@ describe('Data Container Caches', () => {
       cy.get('[data-cy=edit-alias-button]').click();
       // Check modal exists
       cy.get('[data-cy=updateAliasesCacheModal]').should('exist');
+      // add aliases
+      cy.get('[data-cy=menu-toogle-aliasesSelector]')
+        .click().type('newAliasFor' + cacheName)
+        .type('{enter}');
+      cy.get('[data-cy=updateAliasesButton]').click(); //Update aliases
       cy.get('[data-cy=closeAction]').click(); //Closing modal with Close button
+      cy.contains('newAliasFor' + cacheName);
+      cy.contains('alias1');
 
       cy.login(Cypress.env('username'), Cypress.env('password'));
-
+      cy.contains('newAliasFor' + cacheName);
+      cy.contains('alias1');
       cy.get('[data-cy=actions-'+ cacheName + ']').click();
       cy.get('[aria-label=updateAliasesCacheAction]').click();
       // add aliases
@@ -48,13 +56,23 @@ describe('Data Container Caches', () => {
       cy.get('[data-cy=updateAliasesButton]').click(); //Update aliases
       cy.get('[data-cy=closeAction]').click(); //Closing modal with Close button
       cy.contains('alias1').should('not.exist');
+      cy.contains('newAliasFor' + cacheName);
       cy.contains(`Updated ${cacheName} cache: aliases configured successfully`);
 
       // Check detail has aliases
       cy.login(Cypress.env('username'), Cypress.env('password'), '/cache/' + cacheName);
-      cy.contains('Aliases').should('not.exist');
       cy.contains('alias1').should('not.exist');
+      cy.contains('newAliasFor' + cacheName);
+      cy.get('[data-cy=edit-alias-button]').click();
+      cy.get('#clearInput').click();
+      cy.get('[data-cy=updateAliasesButton]').click(); //Update aliases
+      cy.get('[data-cy=closeAction]').click(); //Closing modal with Close button
+      cy.contains('newAliasFor' + cacheName).should('not.exist');
+      cy.contains('No alias');
+
       cy.login(Cypress.env('username'), Cypress.env('password'));
+      cy.contains('newAliasFor' + cacheName).should('not.exist');
+
     });
   });
 });

--- a/cypress/e2e/4_xsite.cy.js
+++ b/cypress/e2e/4_xsite.cy.js
@@ -173,6 +173,10 @@ describe('XSite Config Tests', () => {
                   password: Cypress.env('password')
                 }
               });
+            cy.on("uncaught:exception", (err, runnable) => {
+              cy.log(err.message);
+              return false;
+            });
             cy.get('[data-cy=sideBarToggle]').click();
             cy.contains("NYC");
             cy.contains("xsiteCache");

--- a/cypress/e2e/6_cache-bounded-config-edition.cy.js
+++ b/cypress/e2e/6_cache-bounded-config-edition.cy.js
@@ -53,6 +53,8 @@ describe('Bounded Cache Update', () => {
 
   it('tab is invisible for not bounded caches', () => {
     cy.login(Cypress.env('username'), Cypress.env('password'), '/cache/default');
+    cy.get('[data-cy=detailCacheActions]').click();
+    cy.get('[data-cy=manageConfigEditionLink]').click();
     cy.get('[data-cy=nav-item-Bounded]').should('not.exist');
   });
 });

--- a/cypress/e2e/6_cache-indexed-config-edition.cy.js
+++ b/cypress/e2e/6_cache-indexed-config-edition.cy.js
@@ -28,6 +28,8 @@ describe('Indexed Cache Update', () => {
 
   it('tab is invisible for not indexed caches', () => {
     cy.login(Cypress.env('username'), Cypress.env('password'), '/cache/default');
+    cy.get('[data-cy=detailCacheActions]').click();
+    cy.get('[data-cy=manageConfigEditionLink]').click();
     cy.get('[data-cy=nav-item-Indexed]').should('not.exist');
   });
 });

--- a/cypress/e2e/6_cache-secured-config-edition.cy.js
+++ b/cypress/e2e/6_cache-secured-config-edition.cy.js
@@ -32,8 +32,10 @@ describe('RBAC Cache Update', () => {
     cy.contains("deployer").should('exist');
   });
 
-  it('tab is invisible for not indexed caches', () => {
+  it('tab is invisible for not secured caches', () => {
     cy.login(Cypress.env('username'), Cypress.env('password'), '/cache/default');
-    cy.get('[data-cy=nav-item-Indexed]').should('not.exist');
+    cy.get('[data-cy=detailCacheActions]').click();
+    cy.get('[data-cy=manageConfigEditionLink]').click();
+    cy.get('[data-cy=nav-item-Security]').should('not.exist');
   });
 });

--- a/cypress/e2e/7_local-cache-tests.cy.js
+++ b/cypress/e2e/7_local-cache-tests.cy.js
@@ -1,0 +1,230 @@
+describe('Local Cache Deployment', () => {
+   it('successfully navigates through menu', () => {
+      //Visiting Data Container page
+      cy.origin('http://localhost:41222/console/', () => {
+        cy.visit("/", {
+          headers: {
+            'Accept-Encoding': 'gzip, deflate, br'
+          },
+          auth: {
+            username: Cypress.env('username'),
+            password: Cypress.env('password')
+          }
+        });
+        cy.contains('Running');
+        cy.contains('Tracing is enabled');
+        cy.contains('No caches');
+      });
+
+        //Visiting Global statistics page
+      cy.origin('http://localhost:41222/console/global-stats', () => {
+          cy.visit("/", {
+            headers: {
+              'Accept-Encoding': 'gzip, deflate, br'
+            },
+            auth: {
+              username: Cypress.env('username'),
+              password: Cypress.env('password')
+            }
+          });
+          cy.contains('Cluster-wide statistics');
+       });
+
+        //Visiting Cluster Membership page
+        cy.origin('http://localhost:41222/console/cluster-membership', () => {
+          cy.visit("/", {
+            headers: {
+              'Accept-Encoding': 'gzip, deflate, br'
+            },
+            auth: {
+              username: Cypress.env('username'),
+              password: Cypress.env('password')
+            }
+          });
+          cy.contains('1 member in use');
+          cy.contains('local');
+        });
+
+        //Visiting Access Management page
+        cy.origin('http://localhost:41222/console/access-management', () => {
+          cy.visit("/", {
+            headers: {
+              'Accept-Encoding': 'gzip, deflate, br'
+            },
+            auth: {
+              username: Cypress.env('username'),
+              password: Cypress.env('password')
+            }
+          });
+          cy.contains('observer');
+        });
+
+        //Visiting Connected clients page
+        cy.origin('http://localhost:41222/console/connected-clients', () => {
+          cy.visit("/", {
+            headers: {
+              'Accept-Encoding': 'gzip, deflate, br'
+            },
+            auth: {
+              username: Cypress.env('username'),
+              password: Cypress.env('password')
+            }
+          });
+          cy.contains('Server node')
+        });
+   });
+
+  it('successfully creates cache with all building options', () => {
+    cy.on("uncaught:exception", (err, runnable) => {
+        cy.log(err.message);
+        return false;
+      });
+    cy.origin('http://localhost:41222/console/', () => {
+        cy.visit("/", {
+          headers: {
+            'Accept-Encoding': 'gzip, deflate, br'
+          },
+          auth: {
+            username: Cypress.env('username'),
+            password: Cypress.env('password')
+          }
+        });
+    cy.contains('local');
+    //go to create cache page
+    cy.get('[data-cy=createCacheButton]').click();
+    cy.get('#cache-name').click();
+    cy.get('#cache-name').type('local-test-cache');
+    cy.get('#configure').click();
+    cy.get('[data-cy=wizardNextButton]').click();
+    cy.get('[data-cy=wizardNextButton]').click();
+
+    //Filling bounded  cache properties
+    cy.get('[data-cy=menu-toogle-featuresSelect]').click();
+    cy.get('[data-cy=option-typeahead-BOUNDED]').click();
+
+    cy.get('#size').click();
+    cy.get('[data-cy=memorySizeInput]').clear().type('1');
+    cy.get('[data-cy=toggle-memorySizeUnit]').click();
+    cy.get('#option-KB').click();
+    cy.get('[data-cy=toggle-evictionStrategy]').click();
+    cy.get('#option-REMOVE').click();
+
+    //Filling indexed cache properties
+    cy.get('[data-cy=menu-toogle-featuresSelect]').click();
+    cy.get('[data-cy=option-typeahead-INDEXED').click();
+    cy.get('#persistent').click();
+    cy.get('#auto').click();
+    cy.get('#volatile').click();
+    cy.get('[data-cy=toggle-startupModeSelector]').click();
+    cy.get('#option-reindex').click();
+    cy.get('[data-cy=toggle-startupModeSelector]').click();
+    cy.get('[data-cy=indexSharding]').type(10);
+    cy.get('[data-cy=wizardNextButton]').should('be.disabled');
+    cy.get('[data-cy=menu-toogle-entitiesSelector]').click().type('org.infinispan.Person').type('{enter}');
+    cy.get('[data-cy=menu-toogle-entitiesSelector]').click()
+
+    //Filling auth cache properties
+    cy.get('[data-cy=menu-toogle-featuresSelect]').click();
+    cy.get('[data-cy=option-typeahead-SECURED]').click();
+    cy.get('[data-cy=menu-toogle-roleSelector]').click();
+    cy.get('[data-cy=option-typeahead-admin]').click();
+    cy.get('[data-cy=option-typeahead-application]').click();
+    cy.get('[data-cy=option-typeahead-deployer]').click();
+    cy.get('[data-cy=menu-toogle-roleSelector]').click();
+
+    //Filling persistant cache properties
+    cy.get('[data-cy=menu-toogle-featuresSelect]').click();
+    cy.get('[data-cy=option-typeahead-PERSISTENCE]').click();
+    cy.get('[data-cy=passivationSwitch]').next().click();
+    cy.get('[data-cy=connectionAttempts]').type(5);
+    cy.get('[data-cy=connectionInterval]').type(60);
+    cy.get('[data-cy=availabilityInterval]').type(5000);
+    cy.get('#toggle-persistentStorage').click();
+    cy.get('#option-FileStore').click();
+
+    //Filling transactional cache properties
+    cy.get('[data-cy=menu-toogle-featuresSelect]').click();
+    cy.get('[data-cy=option-typeahead-TRANSACTIONAL]').click();
+    cy.get('#non_xa').click();
+
+    cy.get('#pessimistic').click();
+    cy.get('[data-cy=wizardNextButton]').click();
+
+    cy.get('[data-cy=toggle-storage]').click();
+    cy.get('#option-HEAP').click();
+    cy.get('[data-cy=concurencyLevel]').clear().type(40);
+    cy.get('[data-cy=lockTimeout]').clear().type(15);
+    cy.get('#striping').next().click();
+    //Indexing tuning
+    cy.get('[data-cy=indexReaderExpand] button').click();
+    cy.get('[data-cy=refreshInterval]').type(10);
+    cy.get('[data-cy=indexWriterExpand] button').click();
+    cy.get('#low-level-trace').next().click();
+    cy.get('[data-cy=commitInterval]').type(1001);
+    cy.get('[data-cy=ramBufferSize]').type(33);
+    cy.get('[data-cy=maxBufferedEntries]').type(33);
+    cy.get('[data-cy=threadPoolSize]').type(10);
+    cy.get('[data-cy=queueCount]').type(10);
+    cy.get('[data-cy=queueSize]').type(1050);
+    cy.get('[data-cy=indexMerge] button').click();
+    cy.get('#calibrate-by-deletes').next().click();
+    cy.get('[data-cy=factor]').type(10);
+    cy.get('[data-cy=maxEntries]').type(1000);
+    cy.get('[data-cy=minSize]').type(1000);
+    cy.get('[data-cy=maxSize]').type(10000);
+    cy.get('[data-cy=maxForcedSize]').type(10000);
+    //Transaction tuning
+    cy.get('#read-committed').click();
+    cy.get('[data-cy=stopTimeout]').type(10000);
+    cy.get('[data-cy=completeTimeout]').type(50000);
+    cy.get('[data-cy=reaperInterval]').type(20000);
+
+    //Filling tracing properties
+     cy.get('[data-cy=menu-toogle-categorySelector]').click();
+     cy.get('[data-cy=option-typeahead-persistence]').click();
+     cy.get('[data-cy=menu-toogle-categorySelector]').click();
+
+    //Filling alias
+    cy.get('[data-cy=menu-toogle-aliasesSelector]').click().type('localAlias').type('{enter}');
+
+    // Next
+    cy.get('[data-cy=wizardNextButton]').click();
+
+    //Verify before submitting and downloading file
+    cy.contains('local-test-cache');
+    cy.get('[data-cy=downloadModal]').click();
+    cy.get('[data-cy=downloadButton]').click();
+    cy.wait(2000);
+    let downloadedFile = cy.readFile('./cypress/downloads/local-test-cache.json');
+    downloadedFile.should('exist');
+    downloadedFile.its('local-cache.aliases').should('exist');
+
+    cy.get('[data-cy=downloadModal]').click();
+    cy.get('#modal-XML').click();
+    cy.get('[data-cy=downloadButton]').click();
+    cy.wait(2000);
+    downloadedFile = cy.readFile('./cypress/downloads/local-test-cache.xml');
+    downloadedFile.should('exist');
+
+    cy.get('[data-cy=downloadModal]').click();
+    cy.get('#modal-YAML').click();
+    cy.get('[data-cy=downloadButton]').click();
+    downloadedFile = cy.readFile('./cypress/downloads/local-test-cache.yaml');
+    downloadedFile.should('exist');
+
+    cy.get('[data-cy=wizardNextButton]').click();
+
+    // Once the cache created, redirection to main page is done and the cache should be visible
+    cy.get('[data-ouia-component-id=cluster-manager-header-title]').should('not.exist');
+    cy.get('[data-cy="statusInfo-clusterManager"]').should('not.exist');
+    cy.get('[data-cy=rebalancingSwitch]').should('not.exist');
+    cy.contains('local-test-cache');
+    cy.contains('localAlias');
+    cy.get('[data-cy=feature-local-test-cache]').contains('Bounded');
+    cy.get('[data-cy=feature-local-test-cache]').contains('Indexed');
+    cy.get('[data-cy=feature-local-test-cache]').contains('Secured');
+    cy.get('[data-cy=feature-local-test-cache]').contains('Persistent');
+    cy.get('[data-cy=feature-local-test-cache]').contains('Transactional');
+    });
+  });
+});

--- a/cypress/e2e/8_rolling-upgrades-detection.cy.js
+++ b/cypress/e2e/8_rolling-upgrades-detection.cy.js
@@ -1,0 +1,67 @@
+describe('Rolling Upgrades', () => {
+
+  it('successfully shows the rolling upgrades detection message in NYC', () => {
+    cy.origin('http://localhost:31222/console/', () => {
+      cy.visit("/", {
+        headers: {
+          'Accept-Encoding': 'gzip, deflate, br'
+        },
+        auth: {
+          username: Cypress.env('username'),
+          password: Cypress.env('password')
+        }
+      });
+      cy.get('[data-cy=sideBarToggle]').click();
+      cy.contains("NYC");
+      cy.contains("Rolling Upgrade in Progress — Some features may be temporarily unavailable");
+    })
+  });
+
+  it('successfully shows the different server versions NYC, upgrades server and shows upgrade message', () => {
+    cy.origin('http://localhost:31222/console/', () => {
+      cy.visit("/cluster-membership", {
+        headers: {
+          'Accept-Encoding': 'gzip, deflate, br'
+        },
+        auth: {
+          username: Cypress.env('username'),
+          password: Cypress.env('password')
+        }
+      });
+      cy.get('[data-cy=sideBarToggle]').click();
+      cy.contains("2 members in use");
+      cy.contains("Rolling Upgrade in Progress — Some features may be temporarily unavailable");
+      cy.contains("16.0.0.Dev02");
+      cy.contains("16.0.0-SNAPSHOT");
+
+      // Restarting the docker container with same version and waiting for 20seconds to server to come up, reloading the page
+      cy.exec('bash restart_server_with_latest_version.sh > ~/log.log', 120000).then((result) => {
+         cy.log(result.stdout);
+       }); //waiting for script to finish max for 3 minutes
+      cy.wait(20000)
+      cy.reload();
+
+      cy.get('[data-cy=sideBarToggle]').click();
+      cy.contains("2 members in use");
+      cy.contains("Upgrade Complete — Please clear your browser cache and reconnect to see the latest console version.");
+      cy.contains("16.0.0.Dev02").should('not.exist');
+      cy.contains("16.0.0-SNAPSHOT");
+    })
+  });
+
+  it('successfully refreshes the page and checks that upgrade done message is dissappeared', () => {
+      cy.origin('http://localhost:31222/console/', () => {
+        cy.visit("/", {
+          headers: {
+            'Accept-Encoding': 'gzip, deflate, br'
+          },
+          auth: {
+            username: Cypress.env('username'),
+            password: Cypress.env('password')
+          }
+        });
+        cy.get('[data-cy=sideBarToggle]').click();
+        cy.contains("Upgrade Complete — Please clear your browser cache and reconnect to see the latest console version.").should('not.exist');
+      })
+    });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,6 +23,19 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+const COMMAND_DELAY = 0;
+
+for (const command of ['click', 'trigger', 'type', 'clear', 'reload']) {
+    Cypress.Commands.overwrite(command, (originalFn, ...args) => {
+        const origVal = originalFn(...args);
+
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                resolve(origVal);
+            }, COMMAND_DELAY);
+        });
+    });
+}
 
 Cypress.Commands.add('login', (username, password, url = '/') => {
   cy.visit(url, {

--- a/data/create-data.sh
+++ b/data/create-data.sh
@@ -4,6 +4,7 @@ userPass="$user:$pass"
 echo "= Init create data"
 echo "= Delete caches"
 curl -XDELETE --digest -u $userPass http://localhost:11222/rest/v2/schemas/people
+curl -XDELETE --digest -u $userPass http://localhost:41222/rest/v2/schemas/people
 curl -XDELETE --digest -u $userPass http://localhost:11222/rest/v2/caches/json-cache
 curl -XDELETE --digest -u $userPass http://localhost:11222/rest/v2/caches/xml-cache
 curl -XDELETE --digest -u $userPass http://localhost:11222/rest/v2/caches/java-cache
@@ -24,6 +25,7 @@ echo "= Create schema"
 curl -XPOST --digest -u $userPass -H "Content-Type: application/json" --data-binary "@schemas/people.proto" "http://localhost:11222/rest/v2/schemas/people"
 curl -XPOST --digest -u $userPass -H "Content-Type: application/json" --data-binary "@schemas/child.proto" "http://localhost:11222/rest/v2/schemas/child"
 curl -XPOST --digest -u $userPass -H "Content-Type: application/json" --data-binary "@schemas/car.proto" "http://localhost:11222/rest/v2/schemas/car"
+curl -XPOST --digest -u $userPass -H "Content-Type: application/json" --data-binary "@schemas/people.proto" "http://localhost:41222/rest/v2/schemas/people"
 
 #Creating some more schemas for testing pagination and navigation
 for i in {1..10}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "bundle-profile:analyze": "npm run build:bundle-profile && webpack-bundle-analyzer ./stats.json",
     "clean": "rimraf dist",
     "cy:run": "cypress run --headless",
+    "cy:run:chrome": "cypress run --headless --browser chrome",
+    "cy:run:firefox": "cypress run --headless --browser firefox",
     "cy:e2e": "cypress open"
   },
   "prettier": {

--- a/restart_server_with_latest_version.sh
+++ b/restart_server_with_latest_version.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+if command -v docker &> /dev/null; then
+    echo "Using Docker"
+    DOCKER_COMMAND="docker"
+else
+    echo "Docker not found, using Podman"
+    DOCKER_COMMAND="podman"
+fi
+
+ABSOLUTE_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+echo ${ABSOLUTE_PATH}
+SERVER_IMAGE_URL="${SERVER_IMAGE_URL:-quay.io/infinispan-test/server:main}"
+
+docker stop $(docker ps -aqf "name=ispn-nyc-1")
+docker rm $(docker ps -aqf "name=ispn-nyc-1")
+
+$DOCKER_COMMAND pull ${SERVER_IMAGE_URL}
+$DOCKER_COMMAND run --name ispn-nyc-1 -d -p 51222:11222 -v ${ABSOLUTE_PATH}/scripts/identities.batch:/user-config/identities.batch -v ${ABSOLUTE_PATH}/dist:/opt/infinispan/static/console -v ${ABSOLUTE_PATH}/scripts/e2eTestsConfigNYC.xml:/user-config/e2eTestsConfigNYC.xml -e JAVA_OPTIONS="-Xms1024m -Xmx3072m -XX:MetaspaceSize=1024m -XX:MaxMetaspaceSize=2048m -Dinfinispan.site.name=NYC -Djgroups.mcast_port=46666" -e IDENTITIES_BATCH="/user-config/identities.batch" ${SERVER_IMAGE_URL} --node-name=infinispan-4-nyc-1-e2e -c infinispan-xsite.xml -c "/user-config/e2eTestsConfigNYC.xml"
+
+echo "The container was restarted."
+exit 0;

--- a/run-server-for-e2e-container.sh
+++ b/run-server-for-e2e-container.sh
@@ -10,10 +10,13 @@ fi
 ABSOLUTE_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 echo ${ABSOLUTE_PATH}
 SERVER_IMAGE_URL="${SERVER_IMAGE_URL:-quay.io/infinispan-test/server:main}"
+SERVER_IMAGE_URL_DIFF_VERSION="quay.io/infinispan/server:16.0.0.Dev02-1"
 
 $DOCKER_COMMAND pull ${SERVER_IMAGE_URL}
 $DOCKER_COMMAND run --name ispn-lon -d -p 11222:11222 -v ${ABSOLUTE_PATH}/scripts/identities.batch:/user-config/identities.batch -v ${ABSOLUTE_PATH}/dist:/opt/infinispan/static/console -v ${ABSOLUTE_PATH}/scripts/e2eTestsConfigLON.xml:/user-config/e2eTestsConfigLON.xml -e JAVA_OPTIONS="-Xms1024m -Xmx3072m -XX:MetaspaceSize=1024m -XX:MaxMetaspaceSize=2048m -Dinfinispan.site.name=LON -Djgroups.mcast_port=46656" -e IDENTITIES_BATCH="/user-config/identities.batch" ${SERVER_IMAGE_URL} --node-name=infinispan-4-lon-e2e -c infinispan-xsite.xml -c "/user-config/e2eTestsConfigLON.xml"
 $DOCKER_COMMAND run --name ispn-nyc -d -p 31222:11222 -v ${ABSOLUTE_PATH}/scripts/identities.batch:/user-config/identities.batch -v ${ABSOLUTE_PATH}/dist:/opt/infinispan/static/console -v ${ABSOLUTE_PATH}/scripts/e2eTestsConfigNYC.xml:/user-config/e2eTestsConfigNYC.xml -e JAVA_OPTIONS="-Xms1024m -Xmx3072m -XX:MetaspaceSize=1024m -XX:MaxMetaspaceSize=2048m -Dinfinispan.site.name=NYC -Djgroups.mcast_port=46666" -e IDENTITIES_BATCH="/user-config/identities.batch" ${SERVER_IMAGE_URL} --node-name=infinispan-4-nyc-e2e -c infinispan-xsite.xml -c "/user-config/e2eTestsConfigNYC.xml"
+$DOCKER_COMMAND run --name ispn-nyc-1 -d -p 51222:11222 -v ${ABSOLUTE_PATH}/scripts/identities.batch:/user-config/identities.batch -v ${ABSOLUTE_PATH}/dist:/opt/infinispan/static/console -v ${ABSOLUTE_PATH}/scripts/e2eTestsConfigNYC.xml:/user-config/e2eTestsConfigNYC.xml -e JAVA_OPTIONS="-Xms1024m -Xmx3072m -XX:MetaspaceSize=1024m -XX:MaxMetaspaceSize=2048m -Dinfinispan.site.name=NYC -Djgroups.mcast_port=46666" -e IDENTITIES_BATCH="/user-config/identities.batch" ${SERVER_IMAGE_URL_DIFF_VERSION} --node-name=infinispan-4-nyc-1-e2e -c infinispan-xsite.xml -c "/user-config/e2eTestsConfigNYC.xml"
+$DOCKER_COMMAND run --name ispn-local -d -p 41222:11222 -v ${ABSOLUTE_PATH}/scripts/identities.batch:/user-config/identities.batch -v ${ABSOLUTE_PATH}/dist:/opt/infinispan/static/console -v ${ABSOLUTE_PATH}/scripts/infinispan-local.xml:/user-config/infinispan-local.xml -e JAVA_OPTIONS="-Xms1024m -Xmx3072m -XX:MetaspaceSize=1024m -XX:MaxMetaspaceSize=2048m" -e IDENTITIES_BATCH="/user-config/identities.batch" ${SERVER_IMAGE_URL} --node-name=infinispan-4-local-e2e -c "/user-config/infinispan-local.xml"
 
 #Adding nashorn libraries to both containers
 for containerId in $($DOCKER_COMMAND ps -q)

--- a/scripts/infinispan-local.xml
+++ b/scripts/infinispan-local.xml
@@ -1,0 +1,52 @@
+<infinispan
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="urn:infinispan:config:16.0 https://infinispan.org/schemas/infinispan-config-16.0.xsd
+                            urn:infinispan:server:16.0 https://infinispan.org/schemas/infinispan-server-16.0.xsd"
+      xmlns="urn:infinispan:config:16.0"
+      xmlns:server="urn:infinispan:server:16.0">
+
+   <cache-container name="default" statistics="true">
+     <metrics accurate-size="true"/>
+     <tracing collector-endpoint="http://localhost:4318"
+              enabled="true"
+              exporter-protocol="OTLP"
+              service-name="infinispan-server"
+              security="false" />
+    <security>
+     <authorization/>
+    </security>
+   </cache-container>
+
+   <server xmlns="urn:infinispan:server:16.0">
+      <interfaces>
+         <interface name="public">
+            <inet-address value="${infinispan.bind.address:127.0.0.1}"/>
+         </interface>
+      </interfaces>
+
+      <socket-bindings default-interface="public" port-offset="${infinispan.socket.binding.port-offset:0}">
+         <socket-binding name="default" port="${infinispan.bind.port:11222}"/>
+      </socket-bindings>
+
+      <security>
+         <security-realms>
+            <security-realm name="default">
+               <properties-realm/>
+            </security-realm>
+         </security-realms>
+      </security>
+
+     <endpoints>
+       <endpoint socket-binding="default" security-realm="default" >
+         <hotrod-connector name="hotrod">
+           <authentication>
+             <sasl mechanisms="PLAIN" server-name="infinispan"/>
+           </authentication>
+         </hotrod-connector>
+         <rest-connector name="rest">
+           <authentication mechanisms="BASIC DIGEST"/>
+         </rest-connector>
+       </endpoint>
+     </endpoints>
+   </server>
+</infinispan>

--- a/src/app/Caches/Create/BasicCacheConfigConfigurator.tsx
+++ b/src/app/Caches/Create/BasicCacheConfigConfigurator.tsx
@@ -233,8 +233,8 @@ const BasicCacheConfigConfigurator = (props: { cacheManager: CacheManager }) => 
           hasCheckIcon
           label={
             isStatistics
-              ? t('caches.create.configurations.basic.statistics-disable')
-              : t('caches.create.configurations.basic.statistics-enable')
+              ? t('caches.create.configurations.basic.statistics-enable')
+              : t('caches.create.configurations.basic.statistics-disable')
           }
         />
       </FormGroup>

--- a/src/app/Common/SelectMultiWithChips.tsx
+++ b/src/app/Common/SelectMultiWithChips.tsx
@@ -213,7 +213,7 @@ const SelectMultiWithChips = (props: {
                 props.onClear();
                 textInputRef?.current?.focus();
               }}
-              aria-label="Clear input value"
+              aria-label="Clear input value" id="clearInput"
             >
               <TimesIcon aria-hidden />
             </Button>


### PR DESCRIPTION
Closes: #615 

The PR includes implementation for: 
1. Tests for Local mode;
2. Tests for testing Rolling Upgrades detection
3. A few more tests are added, cleanup stuff added for avoiding random failures, etc.
