### PR TITLE
[#648] GHA Workflows for project planning

### DIFF
--- a/.github/workflows/add_infinispan_release_label_to_issues.yaml
+++ b/.github/workflows/add_infinispan_release_label_to_issues.yaml
@@ -21,6 +21,8 @@ jobs:
       - if: github.event.pull_request.merged == true
         id: get_linked_issue
         shell: bash
+        env: 
+          GH_TOKEN: "${{ secrets.INFINISPAN_RELEASE_TOKEN }}"
         run: >
           echo issue_url=$(node -pe "try{obj=JSON.parse(
           '$(gh pr view ${{ github.event.pull_request.url }} --json closingIssuesReferences)'


### PR DESCRIPTION
  add_issues_to_minor_project.yaml
    New approach since the GitHub API doesn't allow adding to project
  views
    Instead this workflow adds the current Infinispan release as a label
    to issues with pull requests merged to the main branch.
    Add token to use gh cli.

  dump_context.yaml
    Updated to dump the context of pull request actions

Closes 648
