### PR TITLE
[#648] GHA Workflows for project planning

### DIFF
--- a/.github/workflows/add_infinispan_release_label_to_issues.yaml
+++ b/.github/workflows/add_infinispan_release_label_to_issues.yaml
@@ -29,4 +29,7 @@ jobs:
       
       - name: Label issue
         if: ${{ steps.get_linked_issue.outputs.issue_url }}
+        shell: bash
+        env: 
+          GH_TOKEN: "${{ secrets.INFINISPAN_RELEASE_TOKEN }}"
         run: gh issue edit ${{ steps.get_linked_issue.outputs.issue_url }} --add-label ${{ vars.RELEASE }}


### PR DESCRIPTION
  add_issues_to_minor_project.yaml
    New approach since the GitHub API doesn't allow adding to project
  views
    Instead this workflow adds the current Infinispan release as a label
    to issues with pull requests merged to the main branch.
    Add token to use gh cli.

  dump_context.yaml
    Updated to dump the context of pull request actions

Closes 648
