### PR TITLE
[#648] GHA Workflows for project planning

### DIFF
--- a/.github/workflows/add_infinispan_release_label_to_issues.yaml
+++ b/.github/workflows/add_infinispan_release_label_to_issues.yaml
@@ -30,7 +30,8 @@ jobs:
           obj.closingIssuesReferences[0].url}catch(TypeError){}") >> "$GITHUB_OUTPUT"
       
       - name: Label issue
-        if: ${{ steps.get_linked_issue.outputs.issue_url }}
+        # Only run if the issue URL is valid
+        if: ${{ steps.get_linked_issue.outputs.issue_url }} != "undefined"
         shell: bash
         env: 
           GH_TOKEN: "${{ secrets.INFINISPAN_RELEASE_TOKEN }}"


### PR DESCRIPTION
  add_issues_to_minor_project.yaml
    New approach since the GitHub API doesn't allow adding to project
  views
    Instead this workflow adds the current Infinispan release as a label
    to issues with pull requests merged to the main branch.
    Add token to use gh cli.

  dump_context.yaml
    Updated to dump the context of pull request actions

Closes 648
