### PR TITLE
[#708] Fix favicon references in index.html

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -6,27 +6,27 @@
     <meta id="appName" name="application-name" content="Console" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <base href="{{INFINISPAN_BASE_PATH}}" />
-    <link rel="apple-touch-icon" sizes="57x57" href="${require('./app/assets/favicons/apple-icon-57x57.png')}" />
-    <link rel="apple-touch-icon" sizes="60x60" href="${require('./app/assets/favicons/apple-icon-60x60.png')}" />
-    <link rel="apple-touch-icon" sizes="72x72" href="${require('./app/assets/favicons/apple-icon-72x72.png')}" />
-    <link rel="apple-touch-icon" sizes="76x76" href="${require('./app/assets/favicons/apple-icon-76x76.png')}" />
-    <link rel="apple-touch-icon" sizes="114x114" href="${require('./app/assets/favicons/apple-icon-114x114.png')}" />
-    <link rel="apple-touch-icon" sizes="120x120" href="${require('./app/assets/favicons/apple-icon-120x120.png')}" />
-    <link rel="apple-touch-icon" sizes="144x144" href="${require('./app/assets/favicons/apple-icon-144x144.png')}" />
-    <link rel="apple-touch-icon" sizes="152x152" href="${require('./app/assets/favicons/apple-icon-152x152.png')}" />
-    <link rel="apple-touch-icon" sizes="180x180" href="${require('./app/assets/favicons/apple-icon-180x180.png')}" />
+    <link rel="apple-touch-icon" sizes="57x57" href="<%= require('./app/assets/favicons/apple-icon-57x57.png') %>" />
+    <link rel="apple-touch-icon" sizes="60x60" href="<%= require('./app/assets/favicons/apple-icon-60x60.png') %>" />
+    <link rel="apple-touch-icon" sizes="72x72" href="<%= require('./app/assets/favicons/apple-icon-72x72.png') %>" />
+    <link rel="apple-touch-icon" sizes="76x76" href="<%= require('./app/assets/favicons/apple-icon-76x76.png') %>" />
+    <link rel="apple-touch-icon" sizes="114x114" href="<%= require('./app/assets/favicons/apple-icon-114x114.png') %>" />
+    <link rel="apple-touch-icon" sizes="120x120" href="<%= require('./app/assets/favicons/apple-icon-120x120.png') %>" />
+    <link rel="apple-touch-icon" sizes="144x144" href="<%= require('./app/assets/favicons/apple-icon-144x144.png') %>" />
+    <link rel="apple-touch-icon" sizes="152x152" href="<%= require('./app/assets/favicons/apple-icon-152x152.png') %>" />
+    <link rel="apple-touch-icon" sizes="180x180" href="<%= require('./app/assets/favicons/apple-icon-180x180.png') %>" />
     <link
       rel="icon"
       type="image/png"
       sizes="192x192"
-      href="${require('./app/assets/favicons/android-icon-192x192.png')}"
+      href="<%= require('./app/assets/favicons/android-icon-192x192.png') %>"
     />
-    <link rel="icon" type="image/png" sizes="32x32" href="${require('./app/assets/favicons/favicon-32x32.png')}" />
-    <link rel="icon" type="image/png" sizes="96x96" href="${require('./app/assets/favicons/favicon-96x96.png')}" />
-    <link rel="icon" type="image/png" sizes="16x16" href="${require('./app/assets/favicons/favicon-16x16.png')}" />
-    <link rel="manifest" href="${require('./app/assets/favicons/manifest.json')}" />
+    <link rel="icon" type="image/png" sizes="32x32" href="<%= require('./app/assets/favicons/favicon-32x32.png') %>" />
+    <link rel="icon" type="image/png" sizes="96x96" href="<%= require('./app/assets/favicons/favicon-96x96.png') %>" />
+    <link rel="icon" type="image/png" sizes="16x16" href="<%= require('./app/assets/favicons/favicon-16x16.png') %>" />
+    <link rel="manifest" href="<%= require('./app/assets/favicons/manifest.json') %>" />
     <meta name="msapplication-TileColor" content="#ffffff" />
-    <meta name="msapplication-TileImage" content="${require('./app/assets/favicons/ms-icon-144x144.png')" />
+    <meta name="msapplication-TileImage" content="<%= require('./app/assets/favicons/ms-icon-144x144.png') %>" />
     <meta name="theme-color" content="#ffffff" />
   </head>
 

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -96,16 +96,7 @@ module.exports = (env) => {
               'node_modules/@patternfly/react-inline-edit-extension/node_modules/@patternfly/react-styles/css/assets/images'
             ),
           ],
-          type: 'asset/inline',
-          use: [
-            {
-              options: {
-                limit: 5000,
-                outputPath: 'images',
-                name: '[name].[ext]',
-              }
-            }
-          ]
+          type: 'asset/inline'
         },
         {
           test: /\.ttf$/,


### PR DESCRIPTION
Use EJS syntax (<%= %>) instead of JS template literals (${}) for HtmlWebpackPlugin require() calls. Also fix missing closing brace on the `ms-icon-144x144.png` reference.

Closes #708 