### PR TITLE
Add AI agent instructions for coding, testing, reviews, and issues

### DIFF
--- a/.cursor/rules/console.mdc
+++ b/.cursor/rules/console.mdc
@@ -1,0 +1,9 @@
+---
+description: Infinispan Console project guidelines for coding and reviews
+globs:
+alwaysApply: true
+---
+
+# Project Context: Infinispan Console
+
+Read and follow the instructions in AI.md at the repository root.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+# Project Context: Infinispan Console
+
+Read and follow the instructions in AI.md at the repository root.

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,11 @@ reports/
 nohup.out
 batch
 server/server-unzipped/
+# ignore agent-specific instruction files
+CLAUDE.md
+GEMINI.md
+.augment*
+.clinerules
+.goosehints
+AGENTS.md
 .claude/

--- a/AI-CODE.md
+++ b/AI-CODE.md
@@ -1,0 +1,81 @@
+# Coding Instructions
+
+## Tech Stack
+* **TypeScript 5.9** with strict mode
+* **React 18** — functional components with hooks (no class components)
+* **PatternFly 6** — `@patternfly/react-core`, `@patternfly/react-table`, `@patternfly/react-icons`, `@patternfly/react-charts`
+* **React Router v7** — client-side routing with ACL-based route guards
+* **i18next** — internationalization with JSON translation files
+* **Monaco Editor** — for config/schema editing
+* **Webpack 5** — bundler (dev server on port 9000, proxies to Infinispan at port 11222)
+* **Build Tool:** npm (Maven wrapper used only for CI packaging as JAR)
+
+## Project Architecture
+
+* **`src/index.tsx`** — React entry point
+* **`src/app/index.tsx`** — App component (Router, context providers)
+* **`src/app/routes.tsx`** — Route definitions with ACL guards
+* **`src/app/AppLayout/`** — Main layout shell (header, sidebar, navigation)
+* **`src/app/providers/`** — React Context providers (User, Theme, Alerts, CacheDetail, CreateCache, Query, etc.)
+* **`src/app/hooks/`** — Custom React hooks for data fetching and context consumption
+* **`src/app/utils/`** — Shared utility functions
+* **`src/app/Common/`** — Shared reusable components (badges, status indicators, popovers)
+* **`src/app/assets/languages/`** — i18n translation JSON files
+* **`src/services/`** — REST API service layer (`ConsoleServices.ts` is the central entry point)
+* **`src/types/`** — TypeScript type definitions
+
+### Feature directories under `src/app/`
+Each feature area has its own directory: `Caches/`, `CacheManagers/`, `AccessManagement/`, `ClusterStatus/`, `ConnectedClients/`, `Counters/`, `XSite/`, `GlobalStats/`, `IndexManagement/`, `ProtoSchema/`, etc.
+
+## Common Build Commands
+* **Install dependencies:** `npm ci` (clean install) or `npm install`
+* **Dev server:** `npm run start:dev` (http://localhost:9000, proxies API to :11222)
+* **Production build:** `npm run build`
+* **Run unit tests:** `npm test`
+* **Lint:** `npm run eslint`
+* **Format:** `npm run format`
+* **E2E tests (headless):** `npm run cy:run`
+* **E2E tests (interactive):** `npm run cy:e2e`
+
+## Development Standards
+
+### Component Patterns
+* **Functional components only** — never use class components.
+* **Custom hooks for data fetching** — each data source has a hook (e.g., `useFetchCaches`, `useCacheDetail`). Hooks combine state management with service calls.
+* **React Context for state** — no Redux. Providers live in `src/app/providers/`, consumed via custom hooks (e.g., `useConnectedUser()`, `useCacheDetail()`).
+* **PatternFly components** — use PatternFly for all UI elements. Do not introduce alternative UI libraries.
+* **TypeScript path aliases** — use `@app/*`, `@services/*`, `@languages/*`, `@utils/*` instead of relative paths.
+
+### API Layer
+* **Service classes** in `src/services/` wrap REST calls using `FetchCaller` (Fetch API wrapper).
+* **`ConsoleServices`** is the singleton entry point — access services via `ConsoleServices.caches()`, `ConsoleServices.search()`, etc.
+* **Error handling** uses a functional `Either` monad (`src/services/either.ts`) — `right(data)` for success, `left(error)` for failure.
+* **REST endpoints:** V2 at `/rest/v2` (`ConsoleServices.endpoint()`), V3 at `/rest/v3` (`ConsoleServices.endpointV3()`).
+
+### Internationalization (i18n)
+* **All user-visible strings must be translated** — use `const { t } = useTranslation()` and `t('key')`.
+* **Translation files** are JSON in `src/app/assets/languages/`. The primary file is `en.json`.
+* **Add new keys** to `en.json` with descriptive, dot-separated paths (e.g., `caches.entries.read-error`).
+* **Interpolation:** `t('key', { variable: value })`.
+* Do not hardcode user-visible strings in components.
+
+### Code Style
+* **Prettier:** single quotes, 2-space indent, 120 char line width, no trailing commas, semicolons required.
+* **ESLint:** TypeScript + React + react-hooks rules.
+* **Husky + lint-staged:** pre-commit hook runs Prettier on staged files.
+* Run `npm run format` before committing.
+
+### Commit Messages
+* Commit messages must start with `[#00000] Summary` where `00000` is the GitHub issue number.
+* PRs must use the pull request template in `.github/pull_request_template.md`.
+
+### Git Branches
+* Branches should be named `issueid/issue_summary` and use `origin/main` as the upstream.
+
+## Development Platform
+* **Issues:** Use GitHub issue types (Bug, Feature Request, Housekeeping) with templates in `.github/ISSUE_TEMPLATE/`.
+
+## Related Projects
+* **Server:** The Infinispan server source code is in `../infinispan`
+* **Operator:** The Infinispan Operator source code is in `../infinispan-operator`
+* **Website:** The Infinispan website source code is in `../infinispan.github.io`

--- a/AI-ISSUES.md
+++ b/AI-ISSUES.md
@@ -1,0 +1,45 @@
+# Issue Creation Instructions
+
+## Issue Types
+
+Use GitHub issue templates in `.github/ISSUE_TEMPLATE/`:
+
+| Type                | Template              | When to Use                                                          |
+|---------------------|-----------------------|----------------------------------------------------------------------|
+| **Bug**             | `bug_report.yml`      | Something is broken or behaving incorrectly                          |
+| **Feature Request** | `feature_request.yml` | New functionality or enhancement to existing functionality           |
+| **Housekeeping**    | `housekeeping.yml`    | Cleanup, refactoring, dependency updates — not a bug or feature      |
+
+If none of these types apply, blank issues are also allowed.
+
+## Required Fields by Type
+
+### Bug Report
+- **Description** (required) — what is broken
+- **Expected behavior** — what should happen
+- **Actual behavior** — what happens instead
+- **How to reproduce** — steps or link to a reproducer
+- **Environment** — Infinispan version, OS, browser
+
+Note: security vulnerabilities should be reported privately to security@infinispan.org, not as public issues.
+
+### Feature Request
+- **Description** (required) — what the feature does and why it is needed
+- **Implementation ideas** (optional) — technical approach
+
+### Housekeeping
+- **Description** (required) — what needs to be done
+- **Implementation ideas** (optional) — technical approach
+
+## Conventions
+
+- Issue titles should be concise and descriptive
+- Reference related issues and PRs using `#number` format
+- When creating issues from code investigation, include file paths and component names where relevant
+- For UI bugs, include screenshots or screen recordings
+- Commit messages reference issues using `[#00000] Summary` format
+
+## External Resources
+
+- Community discussions: [GitHub Discussions](https://github.com/infinispan/infinispan/discussions)
+- Live chat: [Infinispan Zulip](https://infinispan.zulipchat.com/)

--- a/AI-TEST.md
+++ b/AI-TEST.md
@@ -1,0 +1,133 @@
+# Testing Instructions
+
+## Test Frameworks
+
+Infinispan Console uses two test frameworks:
+
+| Type           | Framework                        | Location               | File Naming          |
+|----------------|----------------------------------|------------------------|----------------------|
+| Unit tests     | Jest + React Testing Library     | `src/__tests__/`       | `*.test.ts(x)`       |
+| E2E tests      | Cypress                          | `cypress/e2e/`         | `*.cy.js`            |
+
+## Writing Unit Tests (Jest + React Testing Library)
+
+### Directory Structure
+
+Tests mirror the source structure under `src/__tests__/`:
+- `src/__tests__/components/` — shared component tests
+- `src/__tests__/views/` — page/view tests
+- `src/__tests__/services/` — service and utility tests
+
+### Example: Component Test
+
+```tsx
+import { MyComponent } from '@app/Common/MyComponent';
+import { render, screen } from '@testing-library/react';
+
+describe('MyComponent', () => {
+  test('renders the expected content', () => {
+    render(<MyComponent status="healthy" />);
+    expect(screen.getByText('Healthy')).toBeDefined();
+  });
+});
+```
+
+### Example: Service/Utility Test
+
+```ts
+import { myUtilFunction } from '@services/myService';
+
+describe('myUtilFunction', () => {
+  test('returns expected result for valid input', () => {
+    expect(myUtilFunction('input')).toBe('expected');
+  });
+});
+```
+
+### Key Utilities
+
+- **`@testing-library/react`** — `render()`, `screen`, `fireEvent`, `waitFor()`
+- **`@testing-library/jest-dom`** — extended matchers (auto-imported via `test-setup.js`)
+- **`src/test-utils.tsx`** — custom render helpers with providers
+- **`src/i18n4Test.js`** — i18n setup for test environment
+
+### Mocking
+
+Jest mocks are configured in `jest.config.js`:
+- CSS/style files are mocked via `__mocks__/styleMock.js`
+- Image/SVG files are mocked via `__mocks__/fileMock.js`
+- `keycloak-js`, `monaco-editor`, and `react-syntax-highlighter` are mocked globally
+
+For service mocking in component tests, use `jest.mock()`:
+```ts
+jest.mock('@services/cacheService', () => ({
+  fetchCaches: jest.fn().mockResolvedValue(mockData)
+}));
+```
+
+## Writing E2E Tests (Cypress)
+
+### Directory Structure
+
+- `cypress/e2e/` — test specs (`.cy.js` files)
+- `cypress/fixtures/` — test data files
+- `cypress/support/` — custom commands and helpers
+- `cypress/plugins/` — Cypress plugins
+
+### Test File Naming
+
+E2E test files use numbered prefixes to control execution order:
+```
+1_cluster-welcome.cy.js       # First: basic cluster/welcome tests
+2_cache-detail.cy.js           # Second: cache detail tests
+3_cache-crud-wizard.cy.js      # Third: cache creation/CRUD tests
+4_xsite.cy.js                  # Fourth: cross-site tests
+```
+
+### Configuration
+
+- **Base URL:** `http://localhost:11222/console/`
+- **Default credentials:** `admin` / `password` (configured in `cypress.config.ts` as env vars)
+- **Retries:** 3 retries per test
+- **Browsers:** Firefox and Chrome supported
+
+### Running E2E Tests
+
+```bash
+# Prerequisites: Infinispan server must be running at localhost:11222
+# Start server with: ./run-server-for-e2e.sh
+
+# Headless (all browsers)
+npm run cy:run
+
+# Chrome only
+npm run cy:run:chrome
+
+# Firefox only
+npm run cy:run:firefox
+
+# Interactive mode (opens Cypress UI)
+npm run cy:e2e
+
+# Via Maven (downloads server, runs tests)
+mvn clean install -De2e=true
+```
+
+## Running Tests
+
+```bash
+# Unit tests
+npm test
+
+# Unit tests with coverage
+npm test -- --coverage
+
+# Run a single test file
+npm test -- --testPathPattern=MyComponent.test
+
+# E2E tests (requires running Infinispan server)
+npm run cy:run
+
+# Full test suite via Maven (unit + e2e)
+mvn clean install -De2e=true
+```

--- a/AI.md
+++ b/AI.md
@@ -1,0 +1,20 @@
+# Project Context: Infinispan Console
+
+Infinispan Console is the web management console for [Infinispan](https://infinispan.org/) server. It is a single-page application built with React 18, TypeScript, and PatternFly 6, served by the Infinispan server at `/console/`.
+
+## Shared guidelines
+- Use the project's established patterns and terminology. When in doubt, follow the conventions of the existing codebase.
+- Prefer clarity over cleverness. This is a long-lived open-source project with many contributors.
+- The console communicates with Infinispan server exclusively via REST API — do not introduce new communication channels.
+
+## Coding instructions
+When planning and writing code, read and follow the instructions in AI-CODE.md.
+
+## Testing instructions
+When writing or modifying tests, read and follow the instructions in AI-TEST.md.
+
+## Issue creation instructions
+When creating GitHub issues, read and follow the instructions in AI-ISSUES.md.
+
+## Pull request review instructions
+When reviewing PRs, read and follow the instructions in REVIEW.md.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,18 @@ Follow this format for commit messages: Start with the JIRA issue number, follow
 ISPN-1234 JIRA TITLE...
 ```
 
+### Use of Generative AI
+
+Generative AI tools may be used to assist in writing code, tests, or documentation, provided that you fully understand every change you submit. The goal is to keep the Console's code consistent and high-quality while respecting reviewers' limited time.
+
+If you use generative AI to assist with your contribution, all the following are required:
+
+* You understand the change. You must be able to explain what your code does and why. Submitting AI-generated code you do not understand is not acceptable.
+* You engage with review feedback. You are expected to respond to questions and comments from reviewers. If you use AI to help draft responses, you must edit and proofread them to ensure they are accurate and address the reviewer's point.
+* You can revise the code yourself. If a reviewer requests changes, you are responsible for addressing them, even if your AI tool is unable to produce a suitable fix.
+* You disclose AI agents usage. Include a note in the PR description indicating the usage of AI agents for generating complete solutions from a prompt (i.e. you do not need to mention a simple AI autocomplete). This helps reviewers calibrate their review.
+* You ensure licensing compliance. All generated code must be released under the Apache License, Version 2.0, the same license as Infinispan. You are responsible for verifying that the tools you use do not introduce additional licensing restrictions.
+
 ### Testing
 Ensure that your code includes unit tests when applicable. All tests should pass before submitting a PR.
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,44 @@
+# Pull Request Reviewing Instructions
+
+GitHub pull requests should use the `.github/pull_request_template.md` file which contains user instructions for
+submitting well-formed pull requests. Ensure that the pull request follows the rules, when they are applicable.
+
+## Verify the author checklist
+
+The PR template includes a self checklist. Verify that checklist items are actually satisfied, not just checked off.
+Pay particular attention to:
+- Manual testing: has the developer actually tested the changes?
+- Test coverage: if tests are missing, is the justification convincing?
+- Screenshots/GIFs: if the PR includes UI changes, are they documented visually?
+- Commit messages reference a GitHub issue in the `[#00000] Summary` format.
+
+## What Important means here
+
+Reserve Important for findings that would break behavior, cause data loss, or block a rollback: incorrect logic,
+broken API calls, missing error handling for REST failures, accessibility violations that block usage, and
+state management bugs that cause stale or inconsistent UI. Style, naming, and refactoring suggestions are Nit at most.
+
+## Console-specific concerns
+
+Watch for these domain-specific issues that general review might miss:
+- **i18n compliance:** all user-visible strings must use `t('key')` from i18next, never hardcoded. New keys must be added to `en.json`.
+- **PatternFly consistency:** new UI elements should use PatternFly components, not custom HTML or third-party UI libraries.
+- **REST API compatibility:** changes to service calls must remain compatible with supported Infinispan server versions. Check that endpoint paths and response shapes match the server API.
+- **State management:** new shared state should use React Context providers in `src/app/providers/`, not prop drilling or ad-hoc global state.
+- **Error handling:** REST calls must handle failure cases via the `Either` pattern. Errors should surface to the user via the alert system (`useApiAlert`).
+- **Accessibility:** PatternFly components have built-in accessibility — verify that custom markup preserves it (ARIA labels, keyboard navigation, screen reader support).
+- **Performance:** watch for unnecessary re-renders caused by missing `useMemo`/`useCallback`, large inline objects in JSX, or context providers that update too broadly.
+
+## Cap the nits
+
+Report at most five Nits per review. If you found more, say "plus N similar items" in the summary instead of posting
+them inline. If everything you found is a Nit, lead the summary with "No blocking issues."
+
+## Do not report
+
+- Anything CI already enforces: lint, formatting, type errors
+- Test-only code that intentionally violates production rules
+
+## CI Failures
+
+- If the CI checks have been executed, look at the results and try to determine if any failures are related to the changes.


### PR DESCRIPTION
Closes: #746

Self checklist (all need to be checked):
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Commit message includes a reference to the corresponding GitHub issue (eg. commit message: "[#746] Add AI agent instructions...").
- [x] Commits have been squashed and self-contained units of work (e.g. 'WIP' and 'Implements feedback' style messages have been removed).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.

## Summary

Add structured AI agent instructions to help AI coding assistants (Claude, Copilot, Cursor, etc.) work effectively with the Infinispan Console codebase. Mirrors the approach used in the main Infinispan repository (infinispan/infinispan#17265).

### New files
- `AI.md` — main entry point with project context and pointers
- `AI-CODE.md` — coding instructions: React/TypeScript/PatternFly patterns, project architecture, build commands, i18n, service layer, code style
- `AI-TEST.md` — testing instructions: Jest + React Testing Library for unit tests, Cypress for E2E
- `AI-ISSUES.md` — issue creation instructions adapted for console's Bug/Feature/Housekeeping templates
- `REVIEW.md` — PR review instructions with frontend-specific concerns (i18n compliance, PatternFly consistency, REST API compatibility, state management, accessibility, performance)
- `.github/copilot-instructions.md` — GitHub Copilot pointer to AI.md
- `.cursor/rules/console.mdc` — Cursor rules pointer to AI.md

### Modified files
- `CONTRIBUTING.md` — added "Use of Generative AI" section with disclosure, understanding, and licensing requirements
- `.gitignore` — added patterns for agent-specific files (CLAUDE.md, GEMINI.md, .augment*, .clinerules, .goosehints, AGENTS.md)

## Testing
No tests needed — documentation-only change. Verified that all referenced paths, commands, and patterns match the current codebase.