### PR TITLE
feat(CacheManagers): add refresh button to Cache Container page

### DIFF
--- a/src/app/CacheManagers/CacheManagers.tsx
+++ b/src/app/CacheManagers/CacheManagers.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import {
+  Button,
   Card,
   CardBody,
   Flex,
@@ -31,7 +32,7 @@ import { useConnectedUser } from '@app/hooks/userManagementHook';
 import { ConsoleServices } from '@services/ConsoleServices';
 import { ConsoleACL } from '@services/securityService';
 import { RebalancingCacheManager } from '@app/Rebalancing/RebalancingCacheManager';
-import { ClusterIcon } from '@patternfly/react-icons';
+import { ClusterIcon, RedoIcon } from '@patternfly/react-icons';
 import { TracingEnabled } from '@app/Common/TracingEnabled';
 import { PageHeader } from '@patternfly/react-component-groups';
 
@@ -51,7 +52,7 @@ const TAB_PATH_MAP: Record<string, string> = {
 
 const CacheManagers = () => {
   const { connectedUser } = useConnectedUser();
-  const { cm, loading, error } = useDataContainer();
+  const { cm, loading, error, reload } = useDataContainer();
   const location = useLocation();
   const initialTab = PATH_TAB_MAP[location.pathname] || '0';
   const [activeTabKey, setActiveTabKey] = useState(initialTab);
@@ -272,6 +273,16 @@ const CacheManagers = () => {
               <ToolbarItem variant="separator"></ToolbarItem>
               <ToolbarItem>
                 <RebalancingCacheManager />
+              </ToolbarItem>
+              <ToolbarItem align={{ default: 'alignEnd' }}>
+                <Button
+                  variant="link"
+                  data-cy="refreshCacheContainer"
+                  icon={<RedoIcon />}
+                  onClick={() => reload()}
+                >
+                  {t('common.actions.refresh')}
+                </Button>
               </ToolbarItem>
             </ToolbarContent>
           </Toolbar>


### PR DESCRIPTION
Closes #503.

### What

Adds a `Refresh` control to the Cache Container page (`src/app/CacheManagers/CacheManagers.tsx`). The page previously had no way to re-fetch the container's cluster state / rebalancing / tracing info without a full browser reload.

### How

`useDataContainer()` already exposes a `reload` function that the `CacheManagerContextProvider` wires to `dataContainerService.getCacheManager()`, so the button is a thin hook-up:

- Destructure `reload` from `useDataContainer()`.
- Add a link-variant PatternFly `Button` as a new `ToolbarItem` at the end of the existing `cluster-manager-sub-header` `Toolbar`, right-aligned via `align={{ default: 'alignEnd' }}`.
- Use `RedoIcon` and the existing `common.actions.refresh` translation key, matching the Cache Detail page's refresh dropdown item (`DetailCache.tsx::buildRefresh`).

### Scope

One file, +13 / -2. No new state, no new service calls, no changes to tab sub-displays (each table display continues to manage its own fetch lifecycle).

### Verification

- `npx prettier --check src/app/CacheManagers/CacheManagers.tsx` → clean.
- `npx tsc --noEmit -p .` → no new errors attributable to this file (pre-existing errors in `AppLayout.tsx` and `IndexedCacheConfigurator.tsx` remain untouched).

### AI disclosure

Per `CONTRIBUTING.md`'s AI-agents usage policy: this PR was drafted with Claude Code. The commit message and PR body were authored via the agent and reviewed before submission. The underlying change is a direct mapping of the existing `DetailCache` refresh precedent onto the Cache Container toolbar, using the `reload` function already exposed by the data container context.