### PR TITLE
Replace link to client downloads fix #848

### DIFF
--- a/src/app/utils/links.ts
+++ b/src/app/utils/links.ts
@@ -1,5 +1,6 @@
-export const hotRodClientsLink = 'https://infinispan.org/hotrod-clients/';
+export const hotRodClientsLink = 'https://infinispan.org/downloads/clients/';
 export const aboutLink = 'https://infinispan.org/get-started/';
-export const tutorialsLink = 'https://github.com/infinispan/infinispan-simple-tutorials';
+export const tutorialsLink =
+  'https://github.com/infinispan/infinispan-simple-tutorials';
 export const blogLink = 'https://infinispan.org/blog/';
 export const apacheLicenseLink = 'https://www.apache.org/licenses/LICENSE-2.0';


### PR DESCRIPTION
Fix #848 replacing link to current client download location.